### PR TITLE
[WarpBuild]: shift workflows to warp-ubuntu-latest-x64-32x

### DIFF
--- a/.github/workflows/hydrun.yaml
+++ b/.github/workflows/hydrun.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: warp-ubuntu-latest-x64-32x
+    runs-on: warp-ubuntu-latest-x64-8x
     strategy:
       matrix:
         target:

--- a/.github/workflows/hydrun.yaml
+++ b/.github/workflows/hydrun.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: buildjet-32vcpu-ubuntu-2204
     strategy:
       matrix:
         target:
@@ -74,7 +74,7 @@ jobs:
           path: ${{ matrix.target.dst }}
 
   publish-linux:
-    runs-on: warp-ubuntu-latest-x64-32x
+    runs-on: buildjet-32vcpu-ubuntu-2204
     needs: build-linux
 
     steps:


### PR DESCRIPTION

## Ready to Warp! 🚀


> [!IMPORTANT]
> We noticed that this repository is public. Please make sure to allow WarpBuild runners to be used by public repositories:
> 1. Go to your organization's [default runner settings page](https://github.com/organizations/loopholelabs/settings/actions/runner-groups/1).
> 2. Check `Allow public repositories`.
>
> For more information, please refer our [documentation](https://docs.warpbuild.com/public-repos)


This PR was raised by WarpBuild to shift the following workflow(s) to the `warp-ubuntu-latest-x64-32x` runner.

1. [hydrun CI](https://github.com/loopholelabs/linux-pvm-ci/blob/master/.github/workflows/hydrun.yaml)

Please review the changes in this PR and merge when ready. You can see the status at your [dashboard](https://app.warpbuild.com).

> [!NOTE]
> **All** the jobs in the workflows are shifted to the chosen runner. If you want to shift only a few jobs, please change the values manually in the workflow files.
----
Switches to using fast runners provisioned on [warpbuild.com](https://warpbuild.com).
