### PR TITLE
Manually run `dracut` after installing the PVM kernel in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ runcmd:
   - dnf config-manager --add-repo 'https://loopholelabs.github.io/linux-pvm-ci/fedora/hetzner/repodata/linux-pvm-ci.repo'
   - dnf install -y kernel-6.7.12_pvm_host_fedora_hetzner-1.x86_64
   - grubby --set-default /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
-  - grubby --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
+  - grubby --copy-default --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
+  - dracut --force --kver 6.7.12-pvm-host-fedora-hetzner
   - reboot
 
 write_files:
@@ -54,7 +55,8 @@ sudo dnf install -y kernel-6.7.12_pvm_host_fedora_hetzner-1.x86_64
 
 ```shell
 sudo grubby --set-default /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
-sudo grubby --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
+sudo grubby --copy-default --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
+sudo dracut --force --kver 6.7.12-pvm-host-fedora-hetzner
 ```
 
 ```shell


### PR DESCRIPTION
On some bare-metal hosts with UEFI and disk encryption (e.g. Equinix Metal), the RPM postinstall scripts for the package generated by `kbuild` don't regenerate the initramfs correctly, leaving the system in a state where after the reboot, all kernel modules are missing. This can be fixed by manually running `dracut` after the package installation on the affected cloud providers.