### PR TITLE
Expand globs in `cloud-init` scripts properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ COMMIT_SHORT := $(shell echo ${COMMIT} | head -c 12)
 obj = fedora/baremetal fedora/hetzner fedora/digitalocean fedora/aws fedora/gcp fedora/ovh fedora/linode \
       rocky/baremetal rocky/hetzner rocky/digitalocean rocky/aws rocky/gcp rocky/ovh rocky/azure rocky/civo rocky/linode \
       alma/baremetal alma/hetzner alma/digitalocean alma/aws alma/gcp alma/ovh alma/azure alma/linode \
-	  amazonlinux/aws \
-+	  fedora-experimental/baremetal fedora-experimental/hetzner fedora-experimental/digitalocean fedora-experimental/aws fedora-experimental/gcp fedora-experimental/ovh fedora-experimental/linode \
+      amazonlinux/aws \
+      fedora-experimental/baremetal fedora-experimental/hetzner fedora-experimental/digitalocean fedora-experimental/aws fedora-experimental/gcp fedora-experimental/ovh fedora-experimental/linode \
       rocky-experimental/baremetal rocky-experimental/hetzner rocky-experimental/digitalocean rocky-experimental/aws rocky-experimental/gcp rocky-experimental/ovh rocky-experimental/azure rocky-experimental/civo rocky-experimental/linode \
       alma-experimental/baremetal alma-experimental/hetzner alma-experimental/digitalocean alma-experimental/aws alma-experimental/gcp alma-experimental/ovh alma-experimental/azure alma-experimental/linode \
       amazonlinux-experimental/aws

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ runcmd:
   - dnf config-manager --add-repo 'https://loopholelabs.github.io/linux-pvm-ci/fedora/hetzner/repodata/linux-pvm-ci.repo' # Or, if you're on Fedora Linux 41+, use `sudo dnf config-manager addrepo --from-repofile 'https://loopholelabs.github.io/linux-pvm-ci/fedora/baremetal/repodata/linux-pvm-ci.repo'`
   - dnf install -y kernel-6.7.12_pvm_host_fedora_hetzner_*-1.x86_64 # You might also want to install kernel-devel-6.7.12_pvm_host_fedora_hetzner_*-1.x86_64.rpm and kernel-headers-6.7.12_pvm_host_fedora_hetzner_*-1.x86_64.rpm if you want to build a module against the kernel
   # Add `- grubby --copy-default --add-kernel=/boot/vmlinuz-6.7.12-pvm-host-amazonlinux-aws --initrd=/boot/initramfs-6.7.12-pvm-host-amazonlinux-aws.img --title="Amazon Linux (6.7.12-pvm-host-amazonlinux-aws)" ` here on Amazon Linux, otherwise it will fail with `The param /boot/vmlinuz-6.7.12-pvm-host-amazonlinux-aws is incorrect`
-  - grubby --set-default /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
-  - grubby --copy-default --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
-  - dracut --force --kver 6.7.12-pvm-host-fedora-hetzner # Append `--no-kernel` on Amazon Linux, otherwise it will fail with `dracut-install: Failed to find module 'xfs'`
+  - grubby --set-default /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner-*
+  - grubby --copy-default --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner-*
+  - dracut --force --kver $(ls /lib/modules/ | grep "^6.7.12-pvm-host-fedora-hetzner-") # Append `--no-kernel` on Amazon Linux, otherwise it will fail with `dracut-install: Failed to find module 'xfs'`
   - reboot
 
 write_files:
@@ -58,9 +58,9 @@ sudo dnf install -y kernel-6.7.12_pvm_host_fedora_hetzner_*-1.x86_64.rpm # You m
 
 ```shell
 # Run `sudo grubby --copy-default --add-kernel=/boot/vmlinuz-6.7.12-pvm-host-amazonlinux-aws --initrd=/boot/initramfs-6.7.12-pvm-host-amazonlinux-aws.img --title="Amazon Linux (6.7.12-pvm-host-amazonlinux-aws)" ` first on Amazon Linux, otherwise it will fail with `The param /boot/vmlinuz-6.7.12-pvm-host-amazonlinux-aws is incorrect`
-sudo grubby --set-default /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
-sudo grubby --copy-default --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner
-sudo dracut --force --kver 6.7.12-pvm-host-fedora-hetzner # Append `--no-kernel` on Amazon Linux, otherwise it will fail with `dracut-install: Failed to find module 'xfs'`
+sudo grubby --set-default /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner-*
+sudo grubby --copy-default --args="pti=off nokaslr lapic=notscdeadline" --update-kernel /boot/vmlinuz-6.7.12-pvm-host-fedora-hetzner-*
+sudo dracut --force --kver $(ls /lib/modules/ | grep "^6.7.12-pvm-host-fedora-hetzner-") # Append `--no-kernel` on Amazon Linux, otherwise it will fail with `dracut-install: Failed to find module 'xfs'`
 ```
 
 ```shell


### PR DESCRIPTION
Fixes a regression where after an installation, the necessary kernel `cmdline` flags weren't applied.